### PR TITLE
Update supported Rust versions.

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ dependencies as well as default compile and install steps.
 
 Currently supported:
 
-  * Rust 1.11
+  * Rust 1.11 - Rust 1.40
   * x86 (32 and 64-bit), ARM (32 and 64-bit) build systems.
   * All Linux architectures that Rust itself supports (Multiple flavors of:
     x86, ARM, PPC, and MIPS)


### PR DESCRIPTION
In my search to a meta-rust layer, I found meta-rust-bin but I continued my search since the readme mentioned "Currently supported: Rust 1.11" making me think this layers was quite outdated.